### PR TITLE
Bugfix/adding crumb gen

### DIFF
--- a/YahooQuotesApi.Test/Tests/HistoryTests.cs
+++ b/YahooQuotesApi.Test/Tests/HistoryTests.cs
@@ -21,8 +21,6 @@ public class HistoryTests : TestBase
 
         var security = await yahooQuotes.GetAsync("IBM", Histories.PriceHistory) ?? throw new ArgumentNullException();
 
-        security = await yahooQuotes.GetAsync("IBM", Histories.PriceHistory) ?? throw new ArgumentNullException();
-
         Assert.NotEmpty(security.PriceHistory.Value);
     }
 

--- a/YahooQuotesApi/Crumb/YahooCrumb.cs
+++ b/YahooQuotesApi/Crumb/YahooCrumb.cs
@@ -40,7 +40,9 @@ public class YahooCrumb
             return StoredCookieAndCrumb;
 
         // Not in cache, request it from Yahoo
+#pragma warning disable CA2000 // Dispose objects before losing scope, HttpClientFactory takes care of managing HttpClient instances
         HttpClient httpClient = _httpClientFactory.CreateClient();
+#pragma warning restore CA2000 
 
         // FC
         Uri fcUrl = new(YahooFcUrl);
@@ -60,8 +62,6 @@ public class YahooCrumb
         response.EnsureSuccessStatusCode();
 
         string crumb = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-
-        httpClient.Dispose();
 
         if (string.IsNullOrEmpty(crumb))
             throw new HttpRequestException($"Could not generate crumb from {YahooGetCrumbUrl} for cookie {cookie.First(x => x.StartsWith("A3", StringComparison.OrdinalIgnoreCase))}");

--- a/YahooQuotesApi/Crumb/YahooCrumb.cs
+++ b/YahooQuotesApi/Crumb/YahooCrumb.cs
@@ -1,0 +1,71 @@
+﻿using System.Net.Http;
+
+namespace YahooQuotesApi.Crumb;
+
+public class YahooCrumb
+{
+    private const string YahooFcUrl = "https://fc.yahoo.com/";
+    private const string YahooGetCrumbUrl = "https://query2.finance.yahoo.com/v1/test/getcrumb";
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    private readonly object _lock = new();
+    private (IEnumerable<string>, string) _storedCookieAndCrumb;
+    private (IEnumerable<string>, string) StoredCookieAndCrumb
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _storedCookieAndCrumb;
+            }
+        }
+        set
+        {
+            lock (_lock)
+            {
+                _storedCookieAndCrumb = value;
+            }
+        }
+    }
+
+    public YahooCrumb(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<(IEnumerable<string>, string)> GetCookieAndCrumb(CancellationToken ct)
+    {
+        // Get from cache
+        if (StoredCookieAndCrumb != default((IEnumerable<string>, string)))
+            return StoredCookieAndCrumb;
+
+        // Not in cache, request it from Yahoo
+        HttpClient httpClient = _httpClientFactory.CreateClient("crumb");
+
+        // FC
+        Uri fcUrl = new(YahooFcUrl);
+
+        using HttpResponseMessage fcResponse = await httpClient.GetAsync(fcUrl, ct).ConfigureAwait(false); //Response could be 404, but we need the cookie (we need a special policy for this, allow 404 for fc.yahoo and do not retry)
+
+        if (!fcResponse.Headers.TryGetValues("Set-Cookie", out var cookie))
+            throw new InvalidOperationException("Set-Cookie header was not present in the response from " + fcUrl);
+
+        // Crumb
+        Uri crumbUrl = new(YahooGetCrumbUrl);
+
+        httpClient.DefaultRequestHeaders.Add("cookie", cookie);
+
+        using HttpResponseMessage response = await httpClient.GetAsync(crumbUrl, ct).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        string crumb = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(crumb))
+            throw new HttpRequestException($"Could not generate crumb from {YahooGetCrumbUrl} for cookie {cookie.First(x => x.StartsWith("A3", StringComparison.OrdinalIgnoreCase))}");
+
+        StoredCookieAndCrumb = (cookie, crumb);
+
+        return StoredCookieAndCrumb;
+    }
+}

--- a/YahooQuotesApi/Snapshot/YahooSnapshot.cs
+++ b/YahooQuotesApi/Snapshot/YahooSnapshot.cs
@@ -58,13 +58,14 @@ public sealed class YahooSnapshot : IDisposable
     {
         // get cookie and crumb value and send it to get uri?
 
-        HttpClient httpClient = HttpClientFactory.CreateClient();
+        HttpClient httpClient = HttpClientFactory.CreateClient("snapshot");
         Uri fcUrl = new("https://fc.yahoo.com/");
         using HttpResponseMessage response1 = await httpClient.GetAsync(fcUrl, ct).ConfigureAwait(false);
         response1.Headers.TryGetValues("Set-Cookie", out var cookieValue);
 
         Uri crumbUrl = new("https://query2.finance.yahoo.com/v1/test/getcrumb");
         using HttpRequestMessage request = new(HttpMethod.Get, crumbUrl);
+        httpClient.DefaultRequestHeaders.Add("cookie", cookieValue);
         request.Headers.Add("cookie", cookieValue);
         using HttpResponseMessage response = await httpClient.GetAsync(crumbUrl, ct).ConfigureAwait(false);
 

--- a/YahooQuotesApi/Snapshot/YahooSnapshot.cs
+++ b/YahooQuotesApi/Snapshot/YahooSnapshot.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -33,16 +34,20 @@ public sealed class YahooSnapshot : IDisposable
     private async Task<Dictionary<Symbol, Security?>> Producer(Symbol[] symbols, CancellationToken ct)
     {
         Dictionary<Symbol, Security?> dict = symbols.ToDictionary(s => s, s => (Security?)null);
+
         if (!symbols.Any())
             return dict;
+
         IEnumerable<JsonElement> elements = await GetElements(symbols, ct).ConfigureAwait(false);
-      
+
         foreach (JsonElement element in elements)
         {
             Security security = new(element, Logger);
             Symbol symbol = security.Symbol;
+
             if (!dict.ContainsKey(symbol))
                 throw new InvalidOperationException(symbol.Name);
+
             dict[symbol] = security;
         }
 
@@ -51,8 +56,25 @@ public sealed class YahooSnapshot : IDisposable
 
     private async Task<IEnumerable<JsonElement>> GetElements(Symbol[] symbols, CancellationToken ct)
     {
+        // get cookie and crumb value and send it to get uri?
+
+        HttpClient httpClient = HttpClientFactory.CreateClient();
+        Uri fcUrl = new("https://fc.yahoo.com/");
+        using HttpResponseMessage response1 = await httpClient.GetAsync(fcUrl, ct).ConfigureAwait(false);
+        response1.Headers.TryGetValues("Set-Cookie", out var cookieValue);
+
+        Uri crumbUrl = new("https://query2.finance.yahoo.com/v1/test/getcrumb");
+        using HttpRequestMessage request = new(HttpMethod.Get, crumbUrl);
+        request.Headers.Add("cookie", cookieValue);
+        using HttpResponseMessage response = await httpClient.GetAsync(crumbUrl, ct).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+        string crumb = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        //
+
         (Uri uri, List<JsonElement> elements)[] datas =
-            GetUris(YahooQuotesBuilder.BaseUrl, symbols)
+            GetUris(YahooQuotesBuilder.BaseUrl, symbols, crumb)
                 .Select(uri => (uri, elements: new List<JsonElement>()))
                 .ToArray();
 
@@ -63,26 +85,27 @@ public sealed class YahooSnapshot : IDisposable
         };
 
         await Parallel.ForEachAsync(datas, parallelOptions, async (data, ct) =>
-            data.elements.AddRange(await MakeRequest(data.uri, ct).ConfigureAwait(false))).ConfigureAwait(false);
+            data.elements.AddRange(await MakeRequest(data.uri, cookieValue, ct).ConfigureAwait(false))).ConfigureAwait(false);
 
         return datas.Select(x => x.elements).SelectMany(x => x);
     }
 
-    private IEnumerable<Uri> GetUris(string baseUrl, IEnumerable<Symbol> symbols)
+    private IEnumerable<Uri> GetUris(string baseUrl, IEnumerable<Symbol> symbols, string crumb)
     {
         return symbols
             .Select(symbol => WebUtility.UrlEncode(symbol.Name))
             .Chunk(100)
-            .Select(s => $"{baseUrl}{string.Join(",", s)}")
+            .Select(s => $"{baseUrl}{string.Join(",", s)}&crumb={crumb}")
             .Select(s => new Uri(s));
     }
 
-    private async Task<JsonElement[]> MakeRequest(Uri uri, CancellationToken ct)
+    private async Task<JsonElement[]> MakeRequest(Uri uri, IEnumerable<string> cookieValue, CancellationToken ct)
     {
         Logger.LogInformation("{Uri}", uri.ToString());
 
         HttpClient httpClient = HttpClientFactory.CreateClient("snapshot");
         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        httpClient.DefaultRequestHeaders.Add("Cookie", cookieValue);
 
         //Don't use GetFromJsonAsync() or GetStreamAsync() because it would throw an exception
         //and not allow reading a json error messages such as NotFound.
@@ -92,8 +115,10 @@ public sealed class YahooSnapshot : IDisposable
 
         if (!jsonDocument.RootElement.TryGetProperty("quoteResponse", out JsonElement quoteResponse))
             throw new InvalidDataException("quoteResponse");
+
         if (!quoteResponse.TryGetProperty("error", out JsonElement error))
             throw new InvalidDataException("error");
+
         if (error.ValueKind is not JsonValueKind.Null)
         {
             string errorMessage = error.ToString();
@@ -105,8 +130,10 @@ public sealed class YahooSnapshot : IDisposable
             }
             throw new InvalidDataException($"Error requesting YahooSnapshot: {errorMessage}");
         }
+
         if (!quoteResponse.TryGetProperty("result", out JsonElement result))
             throw new InvalidDataException("result");
+
         return result.EnumerateArray().ToArray();
     }
 

--- a/YahooQuotesApi/Utilities/Services.cs
+++ b/YahooQuotesApi/Utilities/Services.cs
@@ -54,11 +54,6 @@ internal sealed class Services
     {
         return new ServiceCollection()
 
-            .AddNamedHttpClient("crumb", useCookies: true)
-            .AddPolicyHandler(TimeoutPolicy)
-            .AddPolicyHandler(RetryPolicy)
-            .Services
-
             .AddNamedHttpClient("snapshot")
             .AddPolicyHandler(TimeoutPolicy)
             .AddPolicyHandler(RetryPolicy)
@@ -91,7 +86,7 @@ internal sealed class Services
 
 internal static partial class Xtensions
 {
-    internal static IHttpClientBuilder AddNamedHttpClient(this IServiceCollection serviceCollection, string name, bool useCookies = false)
+    internal static IHttpClientBuilder AddNamedHttpClient(this IServiceCollection serviceCollection, string name)
     {
         return serviceCollection
 
@@ -109,7 +104,7 @@ internal static partial class Xtensions
                 AllowAutoRedirect = false,
                 //MaxConnectionsPerServer: default is int.MaxValue; with HTTP/2, every request tends to reuse the same connection
                 //CookieContainer = new CookieContainer(),
-                UseCookies = useCookies // false by default to allow for manual setting
+                UseCookies = false
             });
     }
 }

--- a/YahooQuotesApi/Utilities/Services.cs
+++ b/YahooQuotesApi/Utilities/Services.cs
@@ -5,6 +5,7 @@ using Polly.Retry;
 using Polly.Timeout;
 using System.Net;
 using System.Net.Http;
+using YahooQuotesApi.Crumb;
 
 namespace YahooQuotesApi;
 
@@ -53,6 +54,11 @@ internal sealed class Services
     {
         return new ServiceCollection()
 
+            .AddNamedHttpClient("crumb", useCookies: true)
+            .AddPolicyHandler(TimeoutPolicy)
+            .AddPolicyHandler(RetryPolicy)
+            .Services
+
             .AddNamedHttpClient("snapshot")
             .AddPolicyHandler(TimeoutPolicy)
             .AddPolicyHandler(RetryPolicy)
@@ -77,6 +83,7 @@ internal sealed class Services
             .AddSingleton<YahooHistory>()
             .AddSingleton<HistoryBaseComposer>()
             .AddSingleton<YahooModules>()
+            .AddSingleton<YahooCrumb>()
 
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
     }
@@ -84,7 +91,7 @@ internal sealed class Services
 
 internal static partial class Xtensions
 {
-    internal static IHttpClientBuilder AddNamedHttpClient(this IServiceCollection serviceCollection, string name)
+    internal static IHttpClientBuilder AddNamedHttpClient(this IServiceCollection serviceCollection, string name, bool useCookies = false)
     {
         return serviceCollection
 
@@ -102,7 +109,7 @@ internal static partial class Xtensions
                 AllowAutoRedirect = false,
                 //MaxConnectionsPerServer: default is int.MaxValue; with HTTP/2, every request tends to reuse the same connection
                 //CookieContainer = new CookieContainer(),
-                UseCookies = false // manual cookie handling, if any
+                UseCookies = useCookies // false by default to allow for manual setting
             });
     }
 }

--- a/YahooQuotesApi/YahooQuotesBuilder.cs
+++ b/YahooQuotesApi/YahooQuotesBuilder.cs
@@ -7,7 +7,7 @@ public sealed class YahooQuotesBuilder
 {
     internal IClock Clock { get; private set; } = SystemClock.Instance;
 
-    private const string ApiDefaultVersion = "v6";
+    private const string ApiDefaultVersion = "v7";
     private string ApiVersion = "";
     internal string BaseUrl { get; private set; }
     private string BaseUrlPattern = "https://query2.finance.yahoo.com/{0}/finance/quote?symbols=";


### PR DESCRIPTION
Added new singleton service called YahooCrumb that generates cookie/crumb pair and caches it. It is used by the YahooSnapshot class when making the request to the quotes endpoint.

No special policy is needed for the requests to generate the cookie and crumb as far as I've seen. The cookie that's used currently has an expiration date that's about 1 year in the future, supposedly the crumb value is valid for the same amount.

All tests pass.